### PR TITLE
Using http.HandleFunc instead of http.Handle

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,19 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 )
 
-type myHandler struct {
-	greeting string
-}
-
-func (mh myHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte(fmt.Sprintf("%v world", mh.greeting)))
-}
-
 func main() {
-	http.Handle("/", &myHandler{greeting: "Hello"})
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello World!"))
+	})
 	http.ListenAndServe(":8000", nil)
 }


### PR DESCRIPTION
Changed to using http.HandleFunc instead of http.Handle.  Less verbose no interface to implement just pass a function with a ResponseWriter and request pointer.